### PR TITLE
Fix: present UI on the topmost UIViewController

### DIFF
--- a/ios/RNAUICallHandler.swift
+++ b/ios/RNAUICallHandler.swift
@@ -202,7 +202,7 @@ class RNAUICallHandler: RCTEventEmitter, AdaptyPaywallControllerDelegate {
         
         DispatchQueue.main.async {
             vc.modalPresentationCapturesStatusBarAppearance = true
-            vc.modalPresentationStyle = .overFullScreen
+            vc.modalPresentationStyle = .formSheet
             
             guard let rootVC = UIApplication.shared.windows.first?.rootViewController else {
                 return ctx.bridgeError(
@@ -211,13 +211,12 @@ class RNAUICallHandler: RCTEventEmitter, AdaptyPaywallControllerDelegate {
                 
             }
             
-            guard !rootVC.isOrContainsAdaptyController else {
-                return ctx.bridgeError(
-                    BridgeError.typeMismatch(name: .view_id, type: "View already presented")
-                )
+            var currentVC = rootVC
+            while currentVC.presentedViewController != nil {
+                currentVC = currentVC.presentedViewController!
             }
-            
-            rootVC.present(vc, animated: true) {
+
+            currentVC.present(vc, animated: true) {
                 ctx.resolve()
             }
         }

--- a/ios/RNAUICallHandler.swift
+++ b/ios/RNAUICallHandler.swift
@@ -202,7 +202,7 @@ class RNAUICallHandler: RCTEventEmitter, AdaptyPaywallControllerDelegate {
         
         DispatchQueue.main.async {
             vc.modalPresentationCapturesStatusBarAppearance = true
-            vc.modalPresentationStyle = .formSheet
+            vc.modalPresentationStyle = .overFullScreen
             
             guard let rootVC = UIApplication.shared.windows.first?.rootViewController else {
                 return ctx.bridgeError(
@@ -210,7 +210,13 @@ class RNAUICallHandler: RCTEventEmitter, AdaptyPaywallControllerDelegate {
                 )
                 
             }
-            
+
+            guard !rootVC.isOrContainsAdaptyController else {
+                return ctx.bridgeError(
+                    BridgeError.typeMismatch(name: .view_id, type: "View already presented")
+                )
+            }
+
             var currentVC = rootVC
             while currentVC.presentedViewController != nil {
                 currentVC = currentVC.presentedViewController!

--- a/ios/RNAUICallHandler.swift
+++ b/ios/RNAUICallHandler.swift
@@ -203,7 +203,7 @@ class RNAUICallHandler: RCTEventEmitter, AdaptyPaywallControllerDelegate {
         DispatchQueue.main.async {
             vc.modalPresentationCapturesStatusBarAppearance = true
             vc.modalPresentationStyle = .overFullScreen
-            
+
             guard let rootVC = UIApplication.shared.windows.first?.rootViewController else {
                 return ctx.bridgeError(
                     BridgeError.typeMismatch(name: .view_id, type: "Failed to find root view controller")


### PR DESCRIPTION
The Adapty UI can't be displayed on top of a React-Native modal or any other component that adds a new UIViewController.

This fix gets the topmost UIViewController and presents the view inside so that it can be displayed on top of modals.